### PR TITLE
영한 번역 위한 모델 추가

### DIFF
--- a/download_models.py
+++ b/download_models.py
@@ -5,6 +5,7 @@ seq2seq_models = [
     "Helsinki-NLP/opus-mt-ko-en",
     "facebook/m2m100_418M",
     "facebook/nllb-200-distilled-600M"
+    "Helsinki-NLP/opus-mt-tc-big-en-ko"
 ]
 language_models = [
     "gpt2"  # 추가된 GPT-2 모델


### PR DESCRIPTION
기존에는 facebook에서 만든 2개의 모델만 영한 번역 지원.
개선위해 영한 번역 위한 모델 추가함